### PR TITLE
Potential fix for code scanning alert no. 19: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/main/java/irutils/MultiKeyIndex.java
+++ b/src/main/java/irutils/MultiKeyIndex.java
@@ -298,7 +298,7 @@ public class MultiKeyIndex {
     throws IOException
   {
     extentsRaf.seek(entry.getAddress());
-    for (int i = 0; i < entry.getNumberOfPostings(); i++) {
+    for (long i = 0; i < entry.getNumberOfPostings(); i++) {
       long offset = extentsRaf.readLong();
       long length = extentsRaf.readLong();
       postingsRaf.seek(offset);


### PR DESCRIPTION
Potential fix for [https://github.com/Arcuity-ai/metamaplite/security/code-scanning/19](https://github.com/Arcuity-ai/metamaplite/security/code-scanning/19)

To fix the issue, the type of the loop variable `i` should be widened to match the type of `entry.getNumberOfPostings()`, which is `long`. This ensures that the comparison is between two values of the same type, avoiding overflow or infinite loop issues. Specifically:

1. Change the type of `i` from `int` to `long` in the `for` loop declaration.
2. Ensure that all operations involving `i` within the loop are compatible with the `long` type.

This change is localized to the `readPostings` method in the file `src/main/java/irutils/MultiKeyIndex.java`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
