### PR TITLE
Potential fix for code scanning alert no. 1: Insertion of sensitive information into log files

### DIFF
--- a/src/main/java/gov/nih/nlm/nls/metamap/lite/EntityLookup5.java
+++ b/src/main/java/gov/nih/nlm/nls/metamap/lite/EntityLookup5.java
@@ -574,7 +574,7 @@ public class EntityLookup5 implements EntityLookup {
       ERToken lastToken = newTokenlist.get(newTokenlist.size() - 1);
       int firstIndex = originalTokenList.indexOf(firstToken);
       int lastIndex = originalTokenList.indexOf(lastToken);
-      logger.debug("firstToken: " + firstToken);
+      logger.debug("Processing first token in the list.");
       logger.debug("lastToken: " + lastToken);
       logger.debug("firstIndex: " + firstIndex);
       logger.debug("lastIndex: " + lastIndex);


### PR DESCRIPTION
Potential fix for [https://github.com/Arcuity-ai/metamaplite/security/code-scanning/1](https://github.com/Arcuity-ai/metamaplite/security/code-scanning/1)

To fix the issue, we should avoid logging the content of `firstToken` directly. Instead, we can log a generic message or metadata that does not expose sensitive information. If logging the content of `firstToken` is necessary for debugging, we should sanitize or mask the data before logging it. Additionally, we should ensure that logging levels are properly configured to prevent debug logs from being enabled in production.

In this case, we will replace the direct logging of `firstToken` with a generic message indicating that the token was processed, without exposing its content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
