### PR TITLE
Potential fix for code scanning alert no. 14: Insertion of sensitive information into log files

### DIFF
--- a/src/main/java/gov/nih/nlm/nls/metamap/lite/mapdb/MapDbLookup.java
+++ b/src/main/java/gov/nih/nlm/nls/metamap/lite/mapdb/MapDbLookup.java
@@ -150,7 +150,7 @@ public class MapDbLookup implements MMLDictionaryLookup<TermInfo> {
 
   public int lookupVariant(String term) {
     int variance = 9;		// maximum variance (should this value be larger?)
-    logger.debug("term: " + term);
+    logger.debug("Processing term.");
     for (String[] varFields: (List<String[]>)this.variantMap.get(term)) {
       if ((varFields[2].toLowerCase().equals(term.toLowerCase()))) {
 	variance = Integer.parseInt(varFields[4]); // use varlevel field


### PR DESCRIPTION
Potential fix for [https://github.com/Arcuity-ai/metamaplite/security/code-scanning/14](https://github.com/Arcuity-ai/metamaplite/security/code-scanning/14)

To fix the issue, sensitive information should not be logged directly. Instead, the logging statement should be modified to avoid including the `term` value or to sanitize it before logging. If the `term` value is necessary for debugging, it should be obfuscated or replaced with a placeholder.

The best approach is to:
1. Remove the direct logging of `term` or replace it with a generic message that does not include sensitive data.
2. If logging `term` is essential, ensure it is sanitized or obfuscated before being logged.

Changes are required in `MapDbLookup.java`:
- Modify the `logger.debug` statement on line 153 to avoid logging the raw `term` value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
